### PR TITLE
ci: pin R to 4.5.2 to match renv.lock

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,9 @@ jobs:
 
       - name: Set up R
         uses: r-lib/actions/setup-r@v2
-  
+        with:
+          r-version: '4.5.2'
+
       - name: Set up R environment
         uses: r-lib/actions/setup-renv@v2
 


### PR DESCRIPTION
## Summary
- Pin `r-lib/actions/setup-r@v2` to R 4.5.2 so the CI R version matches `renv.lock`.
- Fixes the broken Quarto Publish workflow where rlang 1.1.7 failed to compile from source against R 4.6.0 (`R_NamespaceRegistry undeclared`) after GitHub's runner upgraded R on 2026-04-24.

Closes #58

## Test plan
- [ ] Re-run the Quarto Publish workflow on `main` after merge and confirm `Set up R environment` succeeds.